### PR TITLE
Moving the form and segment scripts to tag manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 .DS_Store
 coverage
 *.log
+.env
+.npmrc

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ here.
 
 If you want to add a new script tag to Webflow pages or update existing one
 please [follow this
-documentation](https://www.notion.so/openstore/Marketing-Webflow-Scripts-0705d9fdaf034909b8a2f4a7c80b6528).
-If you want to learn more about the project, how infrastructure around Webflow
+documentation](https://github.com/open-store/marketing-webflow-script/wiki). If
+you want to learn more about the project, how infrastructure around Webflow
 script-tag manager works please continue below.
 
 ## Deployment targets
@@ -58,6 +58,15 @@ environments.](https://s3.console.aws.amazon.com/s3/buckets/marketing-webflow-sc
     script](https://console.statsig.com/jRE7w34M1UUAn7AQKzWVC/gates/webflow_script_stackadapt)
   - [Example dynamic
     configuration](https://console.statsig.com/jRE7w34M1UUAn7AQKzWVC/dynamic_configs/webflow_config_growsurf)
+- DataDog is used to continuously run happy path end-to-end test on webflow
+  pages and ping on-call engineer if they start failing in real time.
+  - [Webflow Marketing Business Pages Happy Path
+    Test](https://app.datadoghq.com/synthetics/details/4pg-55x-5q7)
+- PagerDuty on-call rotation:
+  - [On-call schedule](https://openstore.pagerduty.com/schedules#PX17A75)
+  - [Service](https://openstore.pagerduty.com/service-directory/PKPJACX/activity)
+  - [Escalation
+    policy](https://openstore.pagerduty.com/escalation-policies-ui/P5D349H)
 - Sentry is used to gather error metrics and is configured to alert on specific
   error threshold.
   - [Sentry
@@ -66,16 +75,6 @@ environments.](https://s3.console.aws.amazon.com/s3/buckets/marketing-webflow-sc
     Alerts](https://sentry.io/organizations/openstore-wg/alerts/rules/?project=6588523)
 
 ## Installation and getting started
-
-First you will need to create `.env` file at the root of the project with the
-following environment variables:
-
-```
-AWS_ACCESS_KEY="[YOUR_AWS_ACCESS_KEY]"
-AWS_SECRET_KEY="[YOUR_AWS_SECRET_KEY]"
-```
-
-After that install all the project dependencies:
 
 ```sh
 pnpm install
@@ -98,6 +97,14 @@ pnpm run esbuild:packages:watch
 ```
 
 ## Deployment
+
+First you will need to create `.env` file at the root of the project with the
+following environment variables:
+
+```
+AWS_ACCESS_KEY="[YOUR_AWS_ACCESS_KEY]"
+AWS_SECRET_KEY="[YOUR_AWS_SECRET_KEY]"
+```
 
 Create a fresh build and deploy with following commands:
 

--- a/src/packages/index.ts
+++ b/src/packages/index.ts
@@ -2,12 +2,12 @@
  * This file is the entrypoint of browser builds.
  * The code executes when loaded in a browser.
  */
-import { initializeFeatureFlags, checkGate } from './featureFlags'
+import { initializeFeatureFlags, checkGate } from './utils/featureFlags'
 import {
   initializeErrorTracking,
   addErrorTrackingBreadcrumb,
   captureError,
-} from './errorTracking'
+} from './utils/errorTracking'
 import scripts from './scripts'
 
 async function main() {
@@ -34,6 +34,7 @@ function runAllScripts() {
       // Check for specific feature flag per package script.
       if (checkGate(requireFeatureFlag)) {
         addErrorTrackingBreadcrumb(`Running script: '${scriptName}'`)
+        console.log(`Loader: '${scriptName}'`)
         handler()
       }
     } catch (err) {

--- a/src/packages/utils/errorTracking.ts
+++ b/src/packages/utils/errorTracking.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser'
 import { BrowserTracing } from '@sentry/tracing'
 import { CaptureConsole } from '@sentry/integrations'
-import { SENTRY_DSN_KEY } from './constants'
+import { SENTRY_DSN_KEY } from '../constants'
 
 export function initializeErrorTracking(): void {
   Sentry.init({

--- a/src/packages/utils/featureFlags.ts
+++ b/src/packages/utils/featureFlags.ts
@@ -1,5 +1,5 @@
 import statsig from 'statsig-js'
-import { STATSIG_API_KEY } from './constants'
+import { STATSIG_API_KEY } from '../constants'
 import { captureError } from './errorTracking'
 
 export async function initializeFeatureFlags(): Promise<void> {


### PR DESCRIPTION
# What

Moving the form and segment scripts to tag manager

# Why

We had this scripts compiled and inserted on every webflow page. Consolidating them into the script tag manager for feature flagging and finer control. The scripts add analytics capabilities to the page via Segment handlers as well as handlers for the form submit and form validation via yup.

Analytics handlers were slightly adjusted to not fire the legacy 'page view' events (context: https://www.notion.so/openstore/Client-Side-Event-Schema-8a07885be3d941c68ddf3173d1df013d).

Original scripts code is located here: https://github.com/open-store/frontend/tree/master/packages/marketing-webflow