### PR TITLE
Add click handler for signin and signup links on hompage

### DIFF
--- a/src/packages/scripts.ts
+++ b/src/packages/scripts.ts
@@ -8,6 +8,7 @@ import { isAdBlockerDetected } from './scripts/detectAdBlocker'
 import { plausibleScript } from './scripts/plausibleScript'
 import { bingScript } from './scripts/bingScript'
 import { postalyticsScript } from './scripts/postalyticsScript'
+import { handleSignupSigninLinks } from './scripts/handleSignupSigninLinks'
 
 const segmentOnPageLoad: WebflowScript = {
   requireFeatureFlag: 'webflow_script_segmentonpageload',
@@ -349,5 +350,6 @@ const scripts: WebflowScripts = {
   plausibleScript,
   bingScript,
   postalyticsScript,
+  handleSignupSigninLinks,
 }
 export default scripts

--- a/src/packages/scripts/handleSignupSigninLinks/handleSignupSigninLinks.ts
+++ b/src/packages/scripts/handleSignupSigninLinks/handleSignupSigninLinks.ts
@@ -1,0 +1,42 @@
+import { WebflowScript } from '../../types'
+import { isHomePage, isProd, URLs } from '../../utils/pageChecks'
+
+const handleSignupSigninLinks: WebflowScript = {
+  requireFeatureFlag: 'webflow_script_handle_signup_signin_links',
+  handler: () => {
+    if (!isHomePage()) {
+      console.log('Skipping handleSignupSigninLinks')
+    }
+
+    // new form handling
+    $('.signuplink').each(function () {
+      const signupLink = $(this)
+      signupLink.click(function (evt) {
+        evt.preventDefault()
+
+        const signupBaseUrl = isProd()
+          ? URLs.merchantOpenStore
+          : window.location.origin
+        const searchParams = new URL(window.location.href).searchParams.toString()
+
+        window.location.href = `${signupBaseUrl}/signup${searchParams ? `?${searchParams}` : ''}`
+      })
+    })
+
+    $('.signinlink').each(function () {
+      const signinLink = $(this)
+      signinLink.click(function (evt) {
+        evt.preventDefault()
+
+        const signinBaseUrl = isProd()
+          ? URLs.merchantOpenStore
+          : window.location.origin
+        const searchParams = new URL(window.location.href).searchParams.toString()
+
+        window.location.href = `${signinBaseUrl}/signin${searchParams ? `?${searchParams}` : ''}`
+      })
+    })
+  },
+}
+
+export default handleSignupSigninLinks

--- a/src/packages/scripts/handleSignupSigninLinks/handleSignupSigninLinks.ts
+++ b/src/packages/scripts/handleSignupSigninLinks/handleSignupSigninLinks.ts
@@ -17,9 +17,13 @@ const handleSignupSigninLinks: WebflowScript = {
         const signupBaseUrl = isProd()
           ? URLs.merchantOpenStore
           : window.location.origin
-        const searchParams = new URL(window.location.href).searchParams.toString()
+        const searchParams = new URL(
+          window.location.href,
+        ).searchParams.toString()
 
-        window.location.href = `${signupBaseUrl}/signup${searchParams ? `?${searchParams}` : ''}`
+        window.location.href = `${signupBaseUrl}/signup${
+          searchParams ? `?${searchParams}` : ''
+        }`
       })
     })
 
@@ -31,9 +35,13 @@ const handleSignupSigninLinks: WebflowScript = {
         const signinBaseUrl = isProd()
           ? URLs.merchantOpenStore
           : window.location.origin
-        const searchParams = new URL(window.location.href).searchParams.toString()
+        const searchParams = new URL(
+          window.location.href,
+        ).searchParams.toString()
 
-        window.location.href = `${signinBaseUrl}/signin${searchParams ? `?${searchParams}` : ''}`
+        window.location.href = `${signinBaseUrl}/signin${
+          searchParams ? `?${searchParams}` : ''
+        }`
       })
     })
   },

--- a/src/packages/scripts/handleSignupSigninLinks/handleSignupSigninLinks.ts
+++ b/src/packages/scripts/handleSignupSigninLinks/handleSignupSigninLinks.ts
@@ -6,6 +6,7 @@ const handleSignupSigninLinks: WebflowScript = {
   handler: () => {
     if (!isHomePage()) {
       console.log('Skipping handleSignupSigninLinks')
+      return
     }
 
     // new form handling

--- a/src/packages/scripts/handleSignupSigninLinks/index.ts
+++ b/src/packages/scripts/handleSignupSigninLinks/index.ts
@@ -1,0 +1,1 @@
+export { default as handleSignupSigninLinks } from './handleSignupSigninLinks'

--- a/src/packages/scripts/handleSignupSubmission/handleSignupSubmission.ts
+++ b/src/packages/scripts/handleSignupSubmission/handleSignupSubmission.ts
@@ -5,70 +5,65 @@ import { SIGNUP_FORM_EMAIL_SCHEMA, SIGNUP_FORM_STORE_URL_SCHEMA } from './utils'
 const handleSignupSubmission: WebflowScript = {
   requireFeatureFlag: 'webflow_script_handle_signup_form_submission',
   handler: () => {
-    const $ = (window as any).$ || null
-    const Webflow = (window as any).Webflow || []
+    // === Custom Form Handling ===
 
-    Webflow.push(function () {
-      if ($) {
-        // unbind webflow form handling
-        $(document).off('submit')
+    // unbind webflow form handling
+    $(document).off('submit')
 
-        // new form handling
-        $('.signupform').each( () => {
-          const signupForm = $(this)
-          signupForm.submit( (evt) => {
-            evt.preventDefault()
-            const form = $(this)
-            // The Id of the container has to be set on the two parent above
-            // Webflow does not support parametrizing ID of a symbol (reusuable component), so
-            // the id override needs to happen on one level above
-            const id = form.parent().parent().attr('id')
+    // new form handling
+    $('.signupform').each(function () {
+      const signupForm = $(this)
+      signupForm.submit(function (evt) {
+        evt.preventDefault()
+        const form = $(this)
+        // The Id of the container has to be set on the two parent above
+        // Webflow does not support parametrizing ID of a symbol (reusuable component), so
+        // the id override needs to happen on one level above
+        const id = form.parent().parent().attr('id')
 
-            /**
-             * Use id to locate the corresponding element in the group to support
-             * multiple forms
-             */
-            const submitButton = $(`div#${id} .signupbutton`)
-            const errorMessage = $(`div#${id} .signuperrormessage`)
-            const emailAddress = $(`div#${id} .signupemailaddress`).val()
-            const storeUrl = $(`div#${id} .signupstoreurl`).val()
+        /**
+         * Use id to locate the corresponding element in the group to support
+         * multiple forms
+         */
+        const submitButton = $(`div#${id} .signupbutton`)
+        const errorMessage = $(`div#${id} .signuperrormessage`)
+        const emailAddress = $(`div#${id} .signupemailaddress`).val()
+        const storeUrl = $(`div#${id} .signupstoreurl`).val()
 
-            // Reset error message first
-            errorMessage?.html('')
+        // Reset error message first
+        errorMessage?.html('')
 
-            if (!SIGNUP_FORM_EMAIL_SCHEMA.isValidSync({ emailAddress })) {
-              errorMessage?.html('Enter a valid email')
-              return false
-            }
+        if (!SIGNUP_FORM_EMAIL_SCHEMA.isValidSync({ emailAddress })) {
+          errorMessage?.html('Enter a valid email')
+          return false
+        }
 
-            if (!SIGNUP_FORM_STORE_URL_SCHEMA.isValidSync({ storeUrl })) {
-              errorMessage?.html('Enter a valid URL')
-              return false
-            }
+        if (!SIGNUP_FORM_STORE_URL_SCHEMA.isValidSync({ storeUrl })) {
+          errorMessage?.html('Enter a valid URL')
+          return false
+        }
 
-            // Disable button to prevent double submission
-            const originalText = submitButton.val()
-            submitButton.prop('disabled', true)
-            submitButton.val('Loading....')
+        // Disable button to prevent double submission
+        const originalText = submitButton.val()
+        submitButton.prop('disabled', true)
+        submitButton.val('Loading....')
 
-            const signupBaseUrl = isProd()
-              ? URLs.merchantOpenStore
-              : window.location.origin
-            const searchParams = new URL(window.location.href).searchParams
-            searchParams.set(
-              'emailAddress',
-              encodeURIComponent(emailAddress as string),
-            )
-            searchParams.set('storeUrl', encodeURIComponent(storeUrl as string))
+        const signupBaseUrl = isProd()
+          ? URLs.merchantOpenStore
+          : window.location.origin
+        const searchParams = new URL(window.location.href).searchParams
+        searchParams.set(
+          'emailAddress',
+          encodeURIComponent(emailAddress as string),
+        )
+        searchParams.set('storeUrl', encodeURIComponent(storeUrl as string))
 
-            window.location.href = `${signupBaseUrl}/signup?${searchParams.toString()}`
-            // Reset button state
-            submitButton.prop('disabled', false)
-            submitButton.val(originalText as string)
-            return false
-          })
-        })
-      }
+        window.location.href = `${signupBaseUrl}/signup?${searchParams.toString()}`
+        // Reset button state
+        submitButton.prop('disabled', false)
+        submitButton.val(originalText as string)
+        return false
+      })
     })
   },
 }

--- a/src/packages/scripts/handleSignupSubmission/handleSignupSubmission.ts
+++ b/src/packages/scripts/handleSignupSubmission/handleSignupSubmission.ts
@@ -5,65 +5,70 @@ import { SIGNUP_FORM_EMAIL_SCHEMA, SIGNUP_FORM_STORE_URL_SCHEMA } from './utils'
 const handleSignupSubmission: WebflowScript = {
   requireFeatureFlag: 'webflow_script_handle_signup_form_submission',
   handler: () => {
-    // === Custom Form Handling ===
+    const $ = (window as any).$ || null
+    const Webflow = (window as any).Webflow || []
 
-    // unbind webflow form handling
-    $(document).off('submit')
+    Webflow.push(function () {
+      if ($) {
+        // unbind webflow form handling
+        $(document).off('submit')
 
-    // new form handling
-    $('.signupform').each(function () {
-      const signupForm = $(this)
-      signupForm.submit(function (evt) {
-        evt.preventDefault()
-        const form = $(this)
-        // The Id of the container has to be set on the two parent above
-        // Webflow does not support parametrizing ID of a symbol (reusuable component), so
-        // the id override needs to happen on one level above
-        const id = form.parent().parent().attr('id')
+        // new form handling
+        $('.signupform').each( () => {
+          const signupForm = $(this)
+          signupForm.submit( (evt) => {
+            evt.preventDefault()
+            const form = $(this)
+            // The Id of the container has to be set on the two parent above
+            // Webflow does not support parametrizing ID of a symbol (reusuable component), so
+            // the id override needs to happen on one level above
+            const id = form.parent().parent().attr('id')
 
-        /**
-         * Use id to locate the corresponding element in the group to support
-         * multiple forms
-         */
-        const submitButton = $(`div#${id} .signupbutton`)
-        const errorMessage = $(`div#${id} .signuperrormessage`)
-        const emailAddress = $(`div#${id} .signupemailaddress`).val()
-        const storeUrl = $(`div#${id} .signupstoreurl`).val()
+            /**
+             * Use id to locate the corresponding element in the group to support
+             * multiple forms
+             */
+            const submitButton = $(`div#${id} .signupbutton`)
+            const errorMessage = $(`div#${id} .signuperrormessage`)
+            const emailAddress = $(`div#${id} .signupemailaddress`).val()
+            const storeUrl = $(`div#${id} .signupstoreurl`).val()
 
-        // Reset error message first
-        errorMessage?.html('')
+            // Reset error message first
+            errorMessage?.html('')
 
-        if (!SIGNUP_FORM_EMAIL_SCHEMA.isValidSync({ emailAddress })) {
-          errorMessage?.html('Enter a valid email')
-          return false
-        }
+            if (!SIGNUP_FORM_EMAIL_SCHEMA.isValidSync({ emailAddress })) {
+              errorMessage?.html('Enter a valid email')
+              return false
+            }
 
-        if (!SIGNUP_FORM_STORE_URL_SCHEMA.isValidSync({ storeUrl })) {
-          errorMessage?.html('Enter a valid URL')
-          return false
-        }
+            if (!SIGNUP_FORM_STORE_URL_SCHEMA.isValidSync({ storeUrl })) {
+              errorMessage?.html('Enter a valid URL')
+              return false
+            }
 
-        // Disable button to prevent double submission
-        const originalText = submitButton.val()
-        submitButton.prop('disabled', true)
-        submitButton.val('Loading....')
+            // Disable button to prevent double submission
+            const originalText = submitButton.val()
+            submitButton.prop('disabled', true)
+            submitButton.val('Loading....')
 
-        const signupBaseUrl = isProd()
-          ? URLs.merchantOpenStore
-          : window.location.origin
-        const searchParams = new URL(window.location.href).searchParams
-        searchParams.set(
-          'emailAddress',
-          encodeURIComponent(emailAddress as string),
-        )
-        searchParams.set('storeUrl', encodeURIComponent(storeUrl as string))
+            const signupBaseUrl = isProd()
+              ? URLs.merchantOpenStore
+              : window.location.origin
+            const searchParams = new URL(window.location.href).searchParams
+            searchParams.set(
+              'emailAddress',
+              encodeURIComponent(emailAddress as string),
+            )
+            searchParams.set('storeUrl', encodeURIComponent(storeUrl as string))
 
-        window.location.href = `${signupBaseUrl}/signup?${searchParams.toString()}`
-        // Reset button state
-        submitButton.prop('disabled', false)
-        submitButton.val(originalText as string)
-        return false
-      })
+            window.location.href = `${signupBaseUrl}/signup?${searchParams.toString()}`
+            // Reset button state
+            submitButton.prop('disabled', false)
+            submitButton.val(originalText as string)
+            return false
+          })
+        })
+      }
     })
   },
 }


### PR DESCRIPTION
- Because search params are vital to our marketing attribution, we want to make sure the search params in the original url gets carried over to the signup/signin page on `merchant.open.store`
- The href on the links themselves will remain as `merchant.open.store/signin or signup` so it fulfills SEO requirements