### PR TITLE
Enable new segment code on all pages

### DIFF
--- a/src/packages/scripts.ts
+++ b/src/packages/scripts.ts
@@ -10,42 +10,6 @@ import { bingScript } from './scripts/bingScript'
 import { postalyticsScript } from './scripts/postalyticsScript'
 import { handleSignupSigninLinks } from './scripts/handleSignupSigninLinks'
 
-const segmentOnPageLoad: WebflowScript = {
-  requireFeatureFlag: 'webflow_script_segmentonpageload',
-  handler: () => {
-    const global: any = window
-    // Do not enabled this script on homepage
-    if (isHomePage()) {
-      console.log("Skipping 'legacy-segmentOnPageLoad'")
-      return
-    }
-
-    const removeQueryParams = (pathname: string) => pathname.split('?')[0]
-    // This handler requires for `businessFormAndSegment` to load the Segment
-    // script tag first. It does not load Segment on its own.
-    const handleAnalytics = () => {
-      global.analyticsOS.SegmentBrowser.identify()
-
-      // Replacing old pageView event with custom one that does not fire legacy
-      // events anymore.
-      // global.analyticsOS.analytics.pageView(window.location.pathname)
-      const parsedRoute = removeQueryParams(global.location.pathname)
-      global.analyticsOS.SegmentBrowser.pageView(parsedRoute)
-    }
-
-    // Wait for analyticsOS to load first.
-    const interval = setInterval(function () {
-      if (
-        global?.analyticsOS?.SegmentBrowser?.identify &&
-        global?.analyticsOS?.analytics?.pageView
-      ) {
-        clearInterval(interval)
-        handleAnalytics()
-      }
-    }, 250)
-  },
-}
-
 const webflowOffSubmit: WebflowScript = {
   requireFeatureFlag: 'webflow_script_webflowoffsubmit',
   handler: () => {
@@ -215,12 +179,6 @@ const hubspotScript: WebflowScript = {
 const segmentInitScript: WebflowScript = {
   requireFeatureFlag: 'webflow_script_segment_init',
   handler: () => {
-    // Only enabled this script on homepage
-    if (!isHomePage()) {
-      console.log("Skipping 'segmentInitScript'")
-      return
-    }
-
     // Copied from https://app.segment.com/os-prod/sources/open-store/overview
     /*eslint-disable */
     // @ts-ignore
@@ -297,11 +255,6 @@ const segmentAfterInitScript: WebflowScript = {
   requireFeatureFlag: 'webflow_script_segment_after_init',
   handler: () => {
     const global: any = window
-    // Only enabled this script on homepage
-    if (!isHomePage()) {
-      console.log("Skipping 'segmentAfterInitScript'")
-      return
-    }
 
     const handleAnalytics = async () => {
       const props =
@@ -335,7 +288,6 @@ const segmentAfterInitScript: WebflowScript = {
 }
 
 const scripts: WebflowScripts = {
-  segmentOnPageLoad,
   webflowOffSubmit,
   businessPageHeaderButtons,
   growsurf,

--- a/src/packages/scripts.ts
+++ b/src/packages/scripts.ts
@@ -179,12 +179,6 @@ const hubspotScript: WebflowScript = {
 const segmentInitScript: WebflowScript = {
   requireFeatureFlag: 'webflow_script_segment_init',
   handler: () => {
-    // Only enabled this script on homepage
-    if (!isHomePage()) {
-      console.log("Skipping 'segmentInitScript'")
-      return
-    }
-
     // Copied from https://app.segment.com/os-prod/sources/open-store/overview
     /*eslint-disable */
     // @ts-ignore

--- a/src/packages/scripts.ts
+++ b/src/packages/scripts.ts
@@ -1,7 +1,7 @@
 import { WebflowScript, WebflowScripts } from './types'
 import addScriptTag from '../common/addScriptTag'
 import { getConfig } from './utils/featureFlags'
-import { isBusinessPage, isHomePage, isProd, URLs } from './utils/pageChecks'
+import { isBusinessPage, isProd, URLs } from './utils/pageChecks'
 import { saveAdConversion } from './scripts/saveAdConversion'
 import { handleSignupSubmission } from './scripts/handleSignupSubmission'
 import { isAdBlockerDetected } from './scripts/detectAdBlocker'
@@ -179,6 +179,12 @@ const hubspotScript: WebflowScript = {
 const segmentInitScript: WebflowScript = {
   requireFeatureFlag: 'webflow_script_segment_init',
   handler: () => {
+    // Only enabled this script on homepage
+    if (!isHomePage()) {
+      console.log("Skipping 'segmentInitScript'")
+      return
+    }
+
     // Copied from https://app.segment.com/os-prod/sources/open-store/overview
     /*eslint-disable */
     // @ts-ignore

--- a/src/packages/scripts/handleSignupSubmission/handleSignupSubmission.ts
+++ b/src/packages/scripts/handleSignupSubmission/handleSignupSubmission.ts
@@ -19,7 +19,7 @@ const handleSignupSubmission: WebflowScript = {
         const submitButton = form.find('.signupbutton')
         const errorMessage = form.find('.signuperrormessage')
         const emailAddress = form.find('.signupemailaddress').val()
-        const storeUrl =form.find('.signupstoreurl').val()
+        const storeUrl = form.find('.signupstoreurl').val()
 
         // Reset error message first
         errorMessage?.html('')

--- a/src/packages/scripts/handleSignupSubmission/handleSignupSubmission.ts
+++ b/src/packages/scripts/handleSignupSubmission/handleSignupSubmission.ts
@@ -16,19 +16,10 @@ const handleSignupSubmission: WebflowScript = {
       signupForm.submit(function (evt) {
         evt.preventDefault()
         const form = $(this)
-        // The Id of the container has to be set on the two parent above
-        // Webflow does not support parametrizing ID of a symbol (reusuable component), so
-        // the id override needs to happen on one level above
-        const id = form.parent().parent().attr('id')
-
-        /**
-         * Use id to locate the corresponding element in the group to support
-         * multiple forms
-         */
-        const submitButton = $(`div#${id} .signupbutton`)
-        const errorMessage = $(`div#${id} .signuperrormessage`)
-        const emailAddress = $(`div#${id} .signupemailaddress`).val()
-        const storeUrl = $(`div#${id} .signupstoreurl`).val()
+        const submitButton = form.find('.signupbutton')
+        const errorMessage = form.find('.signuperrormessage')
+        const emailAddress = form.find('.signupemailaddress').val()
+        const storeUrl =form.find('.signupstoreurl').val()
 
         // Reset error message first
         errorMessage?.html('')


### PR DESCRIPTION
- Remove legacy segment loader since it doesn't do anything now
- Remove home page restriction on new segment scripts
- Clean up signup form submission to be element Id agnostic (by using jQuery's `find`)